### PR TITLE
explicitly request metadata fields for table

### DIFF
--- a/DICOMwebBrowser/DICOMwebBrowser.py
+++ b/DICOMwebBrowser/DICOMwebBrowser.py
@@ -77,7 +77,7 @@ class DICOMwebBrowserWidget(ScriptedLoadableModuleWidget):
   def setup(self):
     ScriptedLoadableModuleWidget.setup(self)
 
-    # Ensure that correct version of dicomweb-clien Python package is installed
+    # Ensure that correct version of dicomweb-client Python package is installed
     needRestart = False
     needInstall = False
     minimumDicomwebClientVersion = "0.51"

--- a/DICOMwebBrowser/DICOMwebBrowser.py
+++ b/DICOMwebBrowser/DICOMwebBrowser.py
@@ -579,6 +579,7 @@ Disable if data is added or removed from the database."""
         offset = 0
 
         while True:
+            # request 'StudyDescription' for the UI because the qido-rs spec does not require it be returned
             subset = self.DICOMwebClient.search_for_studies(offset=offset, fields=['StudyDescription'])
             if len(subset) == 0:
                 break
@@ -633,6 +634,7 @@ Disable if data is added or removed from the database."""
 
     else:
       try:
+        # request 'SeriesNumber' for the UI because GCP does not return it by default
         series = self.DICOMwebClient.search_for_series(self.selectedStudyInstanceUID, fields=['SeriesNumber'])
         # Save to cache
         with open(cacheFile, 'w') as f:

--- a/DICOMwebBrowser/DICOMwebBrowser.py
+++ b/DICOMwebBrowser/DICOMwebBrowser.py
@@ -579,7 +579,7 @@ Disable if data is added or removed from the database."""
         offset = 0
 
         while True:
-            subset = self.DICOMwebClient.search_for_studies(offset=offset)
+            subset = self.DICOMwebClient.search_for_studies(offset=offset, fields=["StudyDescription"])
             if len(subset) == 0:
                 break
             if subset[0] in studies:

--- a/DICOMwebBrowser/DICOMwebBrowser.py
+++ b/DICOMwebBrowser/DICOMwebBrowser.py
@@ -579,7 +579,7 @@ Disable if data is added or removed from the database."""
         offset = 0
 
         while True:
-            subset = self.DICOMwebClient.search_for_studies(offset=offset, fields=["StudyDescription"])
+            subset = self.DICOMwebClient.search_for_studies(offset=offset, fields=['StudyDescription'])
             if len(subset) == 0:
                 break
             if subset[0] in studies:
@@ -633,7 +633,7 @@ Disable if data is added or removed from the database."""
 
     else:
       try:
-        series = self.DICOMwebClient.search_for_series(self.selectedStudyInstanceUID)
+        series = self.DICOMwebClient.search_for_series(self.selectedStudyInstanceUID, fields=['SeriesNumber'])
         # Save to cache
         with open(cacheFile, 'w') as f:
           json.dump(series, f)


### PR DESCRIPTION
Then Study and Series UI tables have some fields that are not required to be in a QIDO response. These fields need to be explicitly requested. `StudyDescription` is the only tag currently used in the tables that is not required by the standard

[QIDO Study search required response attributes.](https://dicom.nema.org/medical/dicom/current/output/html/part18.html#table_10.6.3-3)
[QIDO Series search required response attributes.](https://dicom.nema.org/medical/dicom/current/output/html/part18.html#table_10.6.3-4)

Also adds request for `SeriesNumber` for series searches. This is workaround for GCP non-compliance