### PR TITLE
use iterator to download instances

### DIFF
--- a/DICOMwebBrowser/DICOMwebBrowser.py
+++ b/DICOMwebBrowser/DICOMwebBrowser.py
@@ -824,26 +824,24 @@ Disable if data is added or removed from the database."""
 
         instancesAlreadyInDatabase = slicer.dicomDatabase.instancesForSeries(selectedSeries)
 
-        for instanceIndex, instance in enumerate(instances):
+        retrievedInstances = self.DICOMwebClient.iter_series(
+              study_instance_uid=selectedStudy,
+              series_instance_uid=selectedSeries)
+
+        for instanceIndex, retrievedInstance in enumerate(retrievedInstances):
           if self.cancelDownloadRequested:
             break
           if currentDownloadProgressBar:
             currentDownloadProgressBar.setValue(instanceIndex)
           slicer.app.processEvents()
 
-          sopInstanceUid = instance['00080018']['Value'][0]
+          sopInstanceUid = retrievedInstance.SOPInstanceUID
           if sopInstanceUid in instancesAlreadyInDatabase:
             # instance is already in database
             continue
 
           fileName = downloadFolderPath + hashlib.md5(sopInstanceUid.encode()).hexdigest() + '.dcm'
           if not os.path.isfile(fileName) or not self.useCacheFlag:
-            # logging.debug("Downloading file {0} ({1}) from the DICOMweb server".format(
-            #   filename, sopInstanceUid)
-            retrievedInstance = self.DICOMwebClient.retrieve_instance(
-              study_instance_uid=selectedStudy,
-              series_instance_uid=selectedSeries,
-              sop_instance_uid=sopInstanceUid)
             pydicom.filewriter.write_file(fileName, retrievedInstance)
 
         self.clearStatus()

--- a/DICOMwebBrowser/DICOMwebBrowser.py
+++ b/DICOMwebBrowser/DICOMwebBrowser.py
@@ -823,12 +823,27 @@ Disable if data is added or removed from the database."""
         self.seriesTableWidget.scrollToItem(self.seriesTableWidget.item(rowIndex, self.seriesTableHeaderLabels.index('Status')))
 
         instancesAlreadyInDatabase = slicer.dicomDatabase.instancesForSeries(selectedSeries)
+        if instancesAlreadyInDatabase:
+          def instanceGen():
+            # generater that will request and download missing instances one at a time
+            # this is useful if the user has a partially downloaded series
+            seriesSOPInstanceUIDs = {instance['00080018']['Value'][0] for instance in instances}
+            missingSOPInstanceUIDs = list(seriesSOPInstanceUIDs - set(instancesAlreadyInDatabase))
+            for sopInstanceUid in missingSOPInstanceUIDs:
+              yield self.DICOMwebClient.retrieve_instance(
+                study_instance_uid=selectedStudy,
+                series_instance_uid=selectedSeries,
+                sop_instance_uid=sopInstanceUid)
+          retrievedInstances = instanceGen()
+        else:
+          # series not found in database, download everything
+          # iter_series makes a single streaming connection, which is significantly faster
+          # than downloading one instance per request with retrieve_instance
+          retrievedInstances = self.DICOMwebClient.iter_series(
+                study_instance_uid=selectedStudy,
+                series_instance_uid=selectedSeries)
 
-        retrievedInstances = self.DICOMwebClient.iter_series(
-              study_instance_uid=selectedStudy,
-              series_instance_uid=selectedSeries)
-
-        for instanceIndex, retrievedInstance in enumerate(retrievedInstances):
+        for instanceIndex, retrievedInstance in enumerate(retrievedInstances, start=len(instancesAlreadyInDatabase)):
           if self.cancelDownloadRequested:
             break
           if currentDownloadProgressBar:
@@ -836,10 +851,6 @@ Disable if data is added or removed from the database."""
           slicer.app.processEvents()
 
           sopInstanceUid = retrievedInstance.SOPInstanceUID
-          if sopInstanceUid in instancesAlreadyInDatabase:
-            # instance is already in database
-            continue
-
           fileName = downloadFolderPath + hashlib.md5(sopInstanceUid.encode()).hexdigest() + '.dcm'
           if not os.path.isfile(fileName) or not self.useCacheFlag:
             pydicom.filewriter.write_file(fileName, retrievedInstance)

--- a/DICOMwebBrowser/DICOMwebBrowser.py
+++ b/DICOMwebBrowser/DICOMwebBrowser.py
@@ -825,7 +825,7 @@ Disable if data is added or removed from the database."""
         instancesAlreadyInDatabase = slicer.dicomDatabase.instancesForSeries(selectedSeries)
         if instancesAlreadyInDatabase:
           def instanceGen():
-            # generater that will request and download missing instances one at a time
+            # generator that will request and download missing instances one at a time
             # this is useful if the user has a partially downloaded series
             seriesSOPInstanceUIDs = {instance['00080018']['Value'][0] for instance in instances}
             missingSOPInstanceUIDs = list(seriesSOPInstanceUIDs - set(instancesAlreadyInDatabase))


### PR DESCRIPTION
Downloading series by making a request for each instance is significantly slower than downloading the entire series.

Using an example CT series (383.9MB, 721 instances) hosted on GCP dicom dataset.

| download method                    | download time (s) |
| ---------------------------------- | ----------------- |
| `DICOMwebClient.iter_series`       | 22.5 ± 2.8        |
| `DICOMwebClient.retrieve_series`       | 39.4 ± 3.25       |
| `DICOMwebClient.retrieve_instance` | 90 ± 2.21         |

This PR uses `iter_series` to download the entire series.

This code will always download an entire series. I suspect that most of the time the user is going to want to download the entire series. However, if the user has more than 70% of a series already downloaded, then this version will be slower than only downloading the missing instances.
