### PR TITLE
BUG: Fix Kheops error if an out of range offset is specified

### DIFF
--- a/DICOMwebBrowser/DICOMwebBrowser.py
+++ b/DICOMwebBrowser/DICOMwebBrowser.py
@@ -23,7 +23,11 @@ def _get_all_pages(f, *args, **kwargs):
   offset=0
   while True:
     kwargs['offset']=offset
-    subset = f(*args, **kwargs)
+    try:
+      subset = f(*args, **kwargs)
+    except:
+      # Kheops may return 500 error if the offset is too large
+      subset = []
     if len(subset) == 0:
       break
     if subset[0] in data:


### PR DESCRIPTION
Requesting an offset that is out of range from Kheops will currently cause an exception with HTTPS error 500, and prevent indexing/loading of the data.

Fixed by enclosing the call in a try/except block.